### PR TITLE
fix for binary content

### DIFF
--- a/lib/LWP/UserAgent/Cached.pm
+++ b/lib/LWP/UserAgent/Cached.pm
@@ -108,7 +108,7 @@ sub simple_request {
 			
 			if (open my $fh, '>:raw', $fpath) {
 				print $fh $request->url, "\n";
-				print $fh $response->as_string;
+				print $fh $response->as_string("\n");
 				close $fh;
 				
 				push @{$self->{last_cached}}, $fpath;


### PR DESCRIPTION
If no $eol is given then "\n" is added to end content. It is not good for binary content.

perldoc HTTP::Message

    $mess->as_string( $eol )
        Returns the message formatted as a single string.

        The optional $eol parameter specifies the line ending sequence to
        use. The default is "\n". If no $eol is given then as_string will
        ensure that the returned string is newline terminated (even when the
        message content is not). No extra newline is appended if an explicit
        $eol is passed.